### PR TITLE
Run local code instead of cloning it. Fix setup.sh shebang line.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,17 @@ This application illustrates how to implement logging in with Smart-ID on a PHP 
 Setup
 ------------
 Demo has an easy [Docker](https://www.docker.com/what-docker) setup.
-You don't need to download/export repository yourself but bare in mind that this approach always clones the app code from Github.
-If you want to make changes and see them in effect you have to first push the changes to your own forked repo in Github to have the script clone from there.
+You don't need to download/export repository yourself.
 
 1. Install Docker
-2. Either clone the whole repo or only copy `docker-compose.yml` and `docker` directory from repository to local directory
-3. If you want to run a forked repo then add your git username into variable GIT_USERNAME in docker/setup.sh
-3. Open command-line in that directory and run following commands:
-  * `docker-compose build --force-rm`
-  * `docker-compose up`
+2. Clone the whole repo to a local directory
+4. Open command-line in that directory and run following commands:
+  
+   `docker-compose up --build`
 
 Once the script completes the install (takes several minutes) you should have demo application available at [http://localhost:32080](http://localhost:32080).
 Keep the browser's Developer's console Network tab open to the requests arriving from back-end.
+If you change app files then hit CTRL+SHIFT+F5 (CMD+SHIFT+F5 for MAC) to reload changes in browser (no need to restart/rebuild container).
 
 You can now log in with test accounts listed in 
 [smart-id-documentation wiki](https://github.com/SK-EID/smart-id-documentation/wiki/Environment-technical-parameters#accounts).

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ This application illustrates how to implement logging in with Smart-ID on a PHP 
 Setup
 ------------
 Demo has an easy [Docker](https://www.docker.com/what-docker) setup.
-You don't need to download/export repository yourself.
+
 
 1. Install Docker
 2. Clone the whole repo to a local directory
-4. Open command-line in that directory and run following commands:
+4. Open command-line in that directory and run following command:
   
    `docker-compose up --build`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,7 @@ services:
     build: docker
     ports:
       - '32080:80'
+    volumes:
+      - .:/app
 
 # docker-compose up

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,10 +22,8 @@ RUN source $NVM_DIR/nvm.sh \
 ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-RUN mkdir /docker
+COPY setup.sh /setup.sh
 
-COPY setup.sh /docker/setup.sh
+RUN ["chmod", "+x", "/setup.sh"]
 
-RUN ["chmod", "+x", "/docker/setup.sh"]
-
-CMD /bin/bash -c /docker/setup.sh
+CMD /bin/bash -c /setup.sh

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -1,12 +1,8 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 if [ ! -d '/app/bower_components' ]; then
   NODE_VERSION="7.6.0"
-  GIT_USERNAME="SK-EID" # add your own username here if you have forked the original repository
-  GIT_BRANCH="master"
 
-  cd /app
-  git clone -b "$GIT_BRANCH" "https://github.com/$GIT_USERNAME/smart-id-php-demo.git" .
   cd backend
   curl -sS https://getcomposer.org/installer | php
   php composer.phar install


### PR DESCRIPTION
To fasten up development, it is a better idea to mount local directory into container directory (/app). This way one can make changes to files and immediately see the result (after refreshing browser).

Fixed setup.sh first line to work in Windows.